### PR TITLE
Api changes for token support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [23.01/1.3.0] - 2023-12-30
+### Added
+- Token Support for Ethereum stable coin tokens (WETH, USDT, USDC)
+- new endpoints /{currency}/token_txs/{tx_hash} - get token txs per hash
+- new endpoint /{currency}/supported_tokens - list supported tokens
+- new optional parameter token_tx_id on /{currency}/txs to get a specific token transaction
+- Entities contain token balances, and other token related aggregated statistics
+- Ethereum addresses now contain a field is_contract
+- Neighbors contain aggregated token statistics
+
 ## [1.1.1] - 2022-11-25
 ### Added
 - Example for `bulk.json` endpoint.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+all: editor
+
+run-designer:
+	docker run -d -p 8080:8080 swaggerapi/swagger-editor
+	echo 'Designer UI is running on port 8080'
+
+.PHONY: run-designer

--- a/graphsense.yaml
+++ b/graphsense.yaml
@@ -452,6 +452,24 @@ paths:
       summary: Returns exchange rate for a given height
       tags:
         - rates
+  /{currency}/supported_tokens:
+    get:
+      operationId: list_supported_tokens
+      parameters:
+        - $ref: '#/components/parameters/currency' 
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              examples:
+                rates:
+                  $ref: '#/components/examples/token_configs'
+              schema:
+                $ref: '#/components/schemas/token_configs'
+      summary: Returns a list of supported token (sub)currencies.
+      tags:
+        - tokens
   /tags:
     get:
       operationId: list_address_tags
@@ -1724,7 +1742,42 @@ components:
       description: The list of matching labels
       items:
         type: string
+    token_config:
+      type: object
+      required:
+        - ticker
+        - decimals
+      properties:
+        ticker:
+          type: string
+          description: ticker symbol of the currency e.g. USDT
+        decimals:
+          type: integer
+          description: the number of digits after the comma. Values are always delivered as integers. This value can be used to set the decimal point at the right place. 
+        peg_currency:
+          type: string
+          description: is set if token is a stablecoin. It holds the thicker symbol of the currency the tokens is pegged to. 
+    token_configs:
+      type: object
+      required:
+        - token_configs
+      properties:
+        token_configs:
+          type: array
+          description: list of supported tokens and their parameters
+          items:
+            $ref: '#/components/schemas/token_config'
   examples:
+    token_configs:
+      summary: Example token config
+      value:
+        token_configs:
+          - ticker: USDT
+            decimals: 6
+            peg_currency: USD
+          - ticker: WETH
+            decimals: 18
+            peg_currency: ETH
     tx_utxo: 
       summary: UTXO transaction
       value:

--- a/graphsense.yaml
+++ b/graphsense.yaml
@@ -408,8 +408,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/txs_account'
               examples:
-                tx_accounts:
-                  $ref: '#/components/examples/tx_accounts'
+                txs_account:
+                  $ref: '#/components/examples/txs_account'
       summary: Returns all token transactions in a given transaction
       tags:
         - txs

--- a/graphsense.yaml
+++ b/graphsense.yaml
@@ -996,6 +996,8 @@ components:
           $ref: '#/components/schemas/token_values'
         total_tokens_spent: 
           $ref: '#/components/schemas/token_values'
+        is_contract:
+          type: boolean
         status:
           type: string
           enum:

--- a/graphsense.yaml
+++ b/graphsense.yaml
@@ -377,7 +377,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/currency' 
         - $ref: '#/components/parameters/tx_hash' 
-        - $ref: '#/components/parameters/include_io' 
+        - $ref: '#/components/parameters/include_io'
+        - $ref: '#/components/parameters/token_tx_id'
       responses:
         "200":
           description: OK
@@ -391,6 +392,25 @@ paths:
                 tx_account:
                   $ref: '#/components/examples/tx_account'
       summary: Returns details of a specific transaction identified by its hash.
+      tags:
+        - txs
+  /{currency}/token_txs/{tx_hash}:
+    get:
+      operationId: get_token_txs
+      parameters:
+        - $ref: '#/components/parameters/currency' 
+        - $ref: '#/components/parameters/tx_hash' 
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/txs_account'
+              examples:
+                tx_accounts:
+                  $ref: '#/components/examples/tx_accounts'
+      summary: Returns all token transactions in a given transaction
       tags:
         - txs
   /{currency}/txs/{tx_hash}/{io}:
@@ -688,6 +708,14 @@ components:
         type: boolean
         default: false
       description: Whether to include inputs/outputs of a transaction (UTXO only)
+    token_tx_id:
+      in: query
+      name: token_tx_id
+      required: false
+      schema:
+        type: integer
+        default: false
+      description: Select a specific token_transaction (Account model only)
     tag_level:
       in: query
       name: level
@@ -1237,6 +1265,8 @@ components:
           description: The neighbor's tag labels 
         value: 
           $ref: '#/components/schemas/values'
+        token_values:
+          $ref: '#/components/schemas/token_values'
         no_txs: 
           $ref: '#/components/schemas/no_txs'
         address: 
@@ -1255,6 +1285,8 @@ components:
           description: The neighbor's tag labels 
         value: 
           $ref: '#/components/schemas/values'
+        token_values:
+          $ref: '#/components/schemas/token_values'
         no_txs: 
           $ref: '#/components/schemas/no_txs'
         entity: 
@@ -1511,6 +1543,8 @@ components:
         tx_type:
           type: string
           default: 'account'
+        token_tx_id:
+          type: integer
         currency:
           $ref: '#/components/schemas/currency'
         tx_hash:
@@ -1521,12 +1555,15 @@ components:
           $ref: '#/components/schemas/timestamp'
         value:
           $ref: '#/components/schemas/values'
-        token_values:
-          $ref: '#/components/schemas/token_values'
         from_address:
           $ref: '#/components/schemas/address_id'
         to_address:
           $ref: '#/components/schemas/address_id'
+    txs_account:
+      type: array
+      description: A list of account model transactions
+      items: 
+        $ref: '#/components/schemas/tx_account'
     address_txs:
       type: object
       required:

--- a/graphsense.yaml
+++ b/graphsense.yaml
@@ -396,7 +396,7 @@ paths:
         - txs
   /{currency}/token_txs/{tx_hash}:
     get:
-      operationId: get_token_txs
+      operationId: list_token_txs
       parameters:
         - $ref: '#/components/parameters/currency' 
         - $ref: '#/components/parameters/tx_hash' 

--- a/graphsense.yaml
+++ b/graphsense.yaml
@@ -1579,6 +1579,9 @@ components:
           $ref: '#/components/schemas/address_id'
         to_address:
           $ref: '#/components/schemas/address_id'
+        contract_creation:
+          type: boolean
+          description: Indicates if this transaction created a new contract. Recipient address is the address of the new contract. 
     txs_account:
       type: array
       description: A list of account model transactions

--- a/graphsense.yaml
+++ b/graphsense.yaml
@@ -1839,6 +1839,7 @@ components:
       summary: account transaction
       value:
         tx_type: 'account'
+        currency: 'ETH'
         tx_hash: '04d92601677d62a985310b61a301e74870fa942c8be0648e16b1db23b996a8cd'
         height: 47
         timestamp: 123456789
@@ -1849,20 +1850,13 @@ components:
               - code: usd
                 value: 60
             value: 15
-        token_values:
-          USDT:
-            fiat_values:
-              - code: eur
-                value: 58
-              - code: usd
-                value: 60
-            value: 60
         from_address: addressA
         to_address: addressB
     txs_account:
       summary: list of account transactions
       value:
       - tx_type: 'account'
+        currency: 'ETH'
         tx_hash: '04d92601677d62a985310b61a301e74870fa942c8be0648e16b1db23b996a8cd'
         height: 47
         timestamp: 123456789

--- a/graphsense.yaml
+++ b/graphsense.yaml
@@ -1164,13 +1164,13 @@ components:
       additionalProperties:
         $ref: '#/components/schemas/values'
       example:
-        USDT:
+        usdt:
           fiat_values:
             - 0.2
             - 0.3
           value:
             0.2
-        WETH:
+        weth:
           fiat_values:
             - 0.2
             - 0.3

--- a/graphsense.yaml
+++ b/graphsense.yaml
@@ -942,6 +942,8 @@ components:
           $ref: '#/components/schemas/entity_id'
         balance: 
           $ref: '#/components/schemas/values'
+        token_balances:
+          $ref: '#/components/schemas/token_values'
         first_tx: 
           $ref: '#/components/schemas/tx_summary'
         last_tx: 
@@ -962,6 +964,10 @@ components:
           $ref: '#/components/schemas/values'
         total_spent: 
           $ref: '#/components/schemas/values'
+        total_tokens_received: 
+          $ref: '#/components/schemas/token_values'
+        total_tokens_spent: 
+          $ref: '#/components/schemas/token_values'
         status:
           type: string
           enum:
@@ -994,6 +1000,8 @@ components:
           $ref: '#/components/schemas/address_id'
         balance: 
           $ref: '#/components/schemas/values'
+        token_balances:
+          $ref: '#/components/schemas/token_values'
         first_tx: 
           $ref: '#/components/schemas/tx_summary'
         last_tx: 
@@ -1016,6 +1024,10 @@ components:
           $ref: '#/components/schemas/values'
         total_spent: 
           $ref: '#/components/schemas/values'
+        total_tokens_received: 
+          $ref: '#/components/schemas/token_values'
+        total_tokens_spent: 
+          $ref: '#/components/schemas/token_values'
         best_address_tag:
           $ref: '#/components/schemas/address_tag'
         no_address_tags:
@@ -1089,10 +1101,6 @@ components:
           type: string
           description: Tagpack creator
           example: true
-        tagpack_uri:
-          type: string
-          description: Tagpack URI
-          example: true
         is_cluster_definer:
           type: boolean
           description: whether the address tag applies to the entity level
@@ -1120,6 +1128,24 @@ components:
               $ref: '#/components/schemas/address_id'
             entity:
               $ref: '#/components/schemas/entity_id'
+    token_values:
+      type: object
+      description: Per token value-flow
+      additionalProperties:
+        $ref: '#/components/schemas/values'
+      example:
+        USDT:
+          fiat_values:
+            - 0.2
+            - 0.3
+          value:
+            0.2
+        WETH:
+          fiat_values:
+            - 0.2
+            - 0.3
+          value:
+            200000000000000
     values:
       type: object
       required:
@@ -1495,6 +1521,8 @@ components:
           $ref: '#/components/schemas/timestamp'
         value:
           $ref: '#/components/schemas/values'
+        token_values:
+          $ref: '#/components/schemas/token_values'
         from_address:
           $ref: '#/components/schemas/address_id'
         to_address:
@@ -1784,6 +1812,14 @@ components:
               - code: usd
                 value: 60
             value: 15
+        token_values:
+          USDT:
+            fiat_values:
+              - code: eur
+                value: 58
+              - code: usd
+                value: 60
+            value: 60
         from_address: addressA
         to_address: addressB
     txs_account:


### PR DESCRIPTION
Rest api changes to support tokens. 

The main changes in the underlying schema are: 

- Entities and addresses now have total_token_spent and total_token_received fields
- Address relations include a token_values mapping for all token flows
- Address transactions now have a currency field and can have a reference to the tx_id and the log_id if they were token transactions

The changes schema can be found [here](https://github.com/graphsense/graphsense-ethereum-transformation/blob/feature/token-flows/scripts/schema_transformed.cql)